### PR TITLE
Fix non-ensemble alignment tg name

### DIFF
--- a/maps.py
+++ b/maps.py
@@ -322,6 +322,8 @@ if __name__ == '__main__':
         
             if use_ensemble:
                 tgname = tgname_base.parent / tgname_base.parts[-1].replace('.TextGrid', f'_{m_name.stem}.TextGrid')
+            else:
+                tgname = tgname_base
             
             if tgname.is_file() and not overwrite: continue
             


### PR DESCRIPTION
Fix for the TextGrid name variable not matching between different places in the code for non-ensemble alignment.