### PR TITLE
Fix CI to use SD instead of SE

### DIFF
--- a/maps.py
+++ b/maps.py
@@ -373,7 +373,7 @@ if __name__ == '__main__':
         
         if ensemble_table:
             f_path = f'{wavname_path.name}_{model_path.name}_alignment_results.tsv'
-            col_names = ['file', 'word', 'word_mintime', 'word_maxtime', 'segment', 'segment_mintime', 'segment_maxtime', 'segment_se', 'segment_lo_ci', 'segment_hi_ci']
+            col_names = ['file', 'word', 'word_mintime', 'word_maxtime', 'segment', 'segment_mintime', 'segment_maxtime', 'segment_sd', 'segment_lo_ci', 'segment_hi_ci']
             with open(f_path, 'a') as w:
                 w.write('\t'.join(col_names) + '\n')
         
@@ -411,9 +411,9 @@ if __name__ == '__main__':
                 mintime = statistics.mean(mintimes)
                 maxtime = statistics.mean(maxtimes)
                 
-                se = statistics.stdev(maxtimes) / math.sqrt(n_tgs)
-                ci_lo = maxtime - 1.96 * se
-                ci_hi = maxtime + 1.96 * se
+                sd = statistics.stdev(maxtimes)
+                ci_lo = maxtime - 1.96 * sd
+                ci_hi = maxtime + 1.96 * sd
                 if ci_lo == ci_hi:
                     ci_lo -= EPS
                     ci_hi += EPS
@@ -476,9 +476,9 @@ if __name__ == '__main__':
                         else:
                             segment_lo_ci = cis[x_I * 2].time
                             segment_hi_ci = cis[x_I * 2 + 1].time
-                            segment_se = (segment_hi_ci - segment_lo_ci) / (2 * 1.96)
+                            segment_sd = (segment_hi_ci - segment_lo_ci) / (2 * 1.96)
                         
-                        s = [fname, word.mark, word.minTime, word.maxTime, x.mark, x.minTime, x.maxTime, segment_se, segment_lo_ci, segment_hi_ci]
+                        s = [fname, word.mark, word.minTime, word.maxTime, x.mark, x.minTime, x.maxTime, segment_sd, segment_lo_ci, segment_hi_ci]
                         s = '\t'.join([str(z) for z in s])
                         
                         w.write(s + '\n')


### PR DESCRIPTION
The CIs were determined using standard error instead of standard deviation. This is an error because the samples are already from a distribution, akin to a sampling distribution, and so the uncertainty should be estimated using the standard deviation of that distribution.