### PR TITLE
Use median instead of mean for ensemble

### DIFF
--- a/maps.py
+++ b/maps.py
@@ -476,11 +476,11 @@ if __name__ == '__main__':
                 mintimes = [tgs[tier_I].tiers[1].intervals[i].minTime for tier_I in range(n_tgs)]
                 maxtimes = [tgs[tier_I].tiers[1].intervals[i].maxTime for tier_I in range(n_tgs)]
                 
-                mintime = statistics.mean(mintimes)
-                maxtime = statistics.mean(maxtimes)
+                mintime = statistics.median(mintimes)
+                maxtime = statistics.median(maxtimes)
                 
                 sd = statistics.stdev(maxtimes)
-                se = sd / math.sqrt(len(model_names))
+                se = 1.253 * sd / math.sqrt(len(model_names))
                 ci_lo = max(0, maxtime - 1.96 * se)
                 ci_hi = min(maxtime + 1.96 * se, duration)
                 if ci_lo == ci_hi:
@@ -503,8 +503,8 @@ if __name__ == '__main__':
                 mintimes = [tgs[tier_I].tiers[0].intervals[i].minTime for tier_I in range(n_tgs)]
                 maxtimes = [tgs[tier_I].tiers[0].intervals[i].maxTime for tier_I in range(n_tgs)]
                 
-                mintime = statistics.mean(mintimes)
-                maxtime = statistics.mean(maxtimes)
+                mintime = statistics.median(mintimes)
+                maxtime = statistics.median(maxtimes)
                 
                 word_interval = textgrid.Interval(minTime=mintime, maxTime=maxtime, mark=lab)
                 word_intervals.append(word_interval)
@@ -539,7 +539,7 @@ if __name__ == '__main__':
                     
                     for x_I, x in enumerate(intervals):
                         if x_I == len(intervals) - 1:
-                            segment_lo_ci = x.minTime
+                            segment_lo_ci = x.maxTime
                             segment_hi_ci = x.maxTime
                             segment_se = 0
                         else:

--- a/maps.py
+++ b/maps.py
@@ -439,7 +439,7 @@ if __name__ == '__main__':
         
         if ensemble_table:
             f_path = f'{"_".join(wavname_path.parts)}_{model_path.name}_alignment_results.tsv'
-            col_names = ['file', 'word', 'word_mintime', 'word_maxtime', 'segment', 'segment_mintime', 'segment_maxtime', 'segment_se', 'segment_lo_ci', 'segment_hi_ci']
+            col_names = ['file', 'word', 'word_mintime', 'word_maxtime', 'segment', 'segment_mintime', 'segment_maxtime', 'segment_lo_ci', 'segment_hi_ci']
             with open(f_path, 'a') as w:
                 w.write('\t'.join(col_names) + '\n')
         
@@ -479,10 +479,9 @@ if __name__ == '__main__':
                 mintime = statistics.median(mintimes)
                 maxtime = statistics.median(maxtimes)
                 
-                sd = statistics.stdev(maxtimes)
-                se = 1.253 * sd / math.sqrt(len(model_names))
-                ci_lo = max(0, maxtime - 1.96 * se)
-                ci_hi = min(maxtime + 1.96 * se, duration)
+                times_sorted = sorted(maxtimes)
+                ci_lo = times_sorted[1]
+                ci_hi = times_sorted[8]
                 if ci_lo == ci_hi:
                     ci_lo -= EPS
                     ci_hi += EPS
@@ -541,13 +540,11 @@ if __name__ == '__main__':
                         if x_I == len(intervals) - 1:
                             segment_lo_ci = x.maxTime
                             segment_hi_ci = x.maxTime
-                            segment_se = 0
                         else:
                             segment_lo_ci = cis[x_I * 2].time
                             segment_hi_ci = cis[x_I * 2 + 1].time
-                            segment_se = (segment_hi_ci - segment_lo_ci) / (2 * 1.96)
                         
-                        s = [fname, word.mark, word.minTime, word.maxTime, x.mark, x.minTime, x.maxTime, segment_se, segment_lo_ci, segment_hi_ci]
+                        s = [fname, word.mark, word.minTime, word.maxTime, x.mark, x.minTime, x.maxTime, segment_lo_ci, segment_hi_ci]
                         s = '\t'.join([str(z) for z in s])
                         
                         w.write(s + '\n')


### PR DESCRIPTION
The median of the ensemble is more robust to outliers than the mean, and order statistics provide a robust confidence interval.