### PR TITLE
Use wavname path for textgrids during resampling

### DIFF
--- a/maps.py
+++ b/maps.py
@@ -321,7 +321,7 @@ if __name__ == '__main__':
     use_interp = (args['interp'] == 'true')        
     add_sil = (args['sil'] == 'true')
     
-    tgnames = [x.with_suffix('.TextGrid') for x in wavnames]
+    tgnames = [wavname_path / (x.stem + '.TextGrid') for x in wavnames]
     
     word_list = []
     for t in transcriptions:


### PR DESCRIPTION
The path names for the textgrids when resampling end up being the temp dir, which is undesired. This patch fixes that issue.