### PR TITLE
Add variant limit and shuffle features

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,16 @@ options:
   --ensemble-table      Flags program to write ensemble results to a table. Appends to a filename based on
                         path to the audio and the path to the model. You may need to delete rows from
                         previous runs if they are not needed.
+  --variant-limit VARIANT_LIMIT
+                        If value given, limits the number of variants checked to the passed value.
+                        Will have no effect without the --check-variants flag
+  --variant-shuffle     If set, shuffles the variants so as to not get stuck with only checking
+                        variants at one end of an utterance under the limit. In the case of
+                        massive combinatoric explostion, this flag may cause memory issues when it
+                        collects the possible variant combinations into a list and shuffles them.
+  --variant-seed VARIANT_SEED
+                        If value given, uses passed value as the random seed for shuffling the
+                        variants for reproducibility.
 
 ```
 

--- a/args.py
+++ b/args.py
@@ -20,5 +20,8 @@ def build_arg_parser():
     p.add_argument('--check-variants', action='store_true', help='Checks pronunciation variants in the dictionary. This is currently VERY slow')
     p.add_argument('--overwrite', action='store_true', help='If flag is set, existing TextGrid files with the same stem as the WAV files will be overwritten')
     p.add_argument('--ensemble-table', action='store_true', help='Flags program to write ensemble results to a table. Appends to a filename based on path to the audio and the path to the model. You may need to delete rows from previous runs if they are not needed.')
+    p.add_argument('--variant-limit', type=int, help='If value given, limits the number of variants checked to the passed value. Will have no effect without the --check-variants flag')
+    p.add_argument('--variant-shuffle', action='store_true', help='If set, shuffles the variants so as to not get stuck with only checking variants at one end of an utterance under the limit. In the case of massive combinatoric explostion, this flag may cause memory issues when it collects the possible variant combinations into a list and shuffles them.')
+    p.add_argument('--variant-seed', type=int, help='If value given, uses passed value as the random seed for shuffling the variants for reproducibility.')
 
     return p


### PR DESCRIPTION
This commit adds flags to allow for limiting the number of variants checked and allows the option to shuffle the variants before checking. It also speeds up the variant checking by ignoring stress in checked variants since the score will not be affected due to a current lack of stress models.